### PR TITLE
Add empty .eslintrc.json to JS projects

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -157,6 +157,7 @@ var NodeModuleGenerator = yeoman.Base.extend({
             case 'js':
                 mkdirp.sync('lib');
                 this.copy('index.js', 'lib/index.js');
+                this.template('_.eslintrc.json', '.eslintrc.json');
                 break;
         }
 

--- a/app/templates/_.eslintrc.json
+++ b/app/templates/_.eslintrc.json
@@ -1,6 +1,8 @@
 {
+    <% if(language === 'babel' || language === 'babel-node4') { %>
     "parser": "babel-eslint",
     "env": {
         "es6": true
     }
+    <% } %>
 }

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -77,6 +77,7 @@ test.serial('creates expected files for Babel', async t => {
         '.babelrc',
         '.gitignore',
         '.npmignore',
+        '.eslintrc.json',
         'package.json',
         'README.md',
         'LICENSE'
@@ -120,6 +121,7 @@ test.serial('creates expected files for Babel with Node 4 preset', async t => {
         '.babelrc',
         '.gitignore',
         '.npmignore',
+        '.eslintrc.json',
         'package.json',
         'README.md',
         'LICENSE'
@@ -159,6 +161,7 @@ test.serial('creates expected files for vanilla Javascript', async t => {
         'test',
         '.gitignore',
         '.npmignore',
+        '.eslintrc.json',
         'package.json',
         'README.md',
         'LICENSE'


### PR DESCRIPTION
ESLint gets mad if you don't give it any configs now, so we appease the lord with {}

Fixes #24 