### PR TITLE
Allow ES6 in JS project linting & fix ava lint

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -161,6 +161,7 @@ var NodeModuleGenerator = yeoman.Base.extend({
                 this.copy('index.js', 'lib/index.js');
                 this.copy('test.js', 'test/test.js');
                 this.template('_.eslintrc.json', '.eslintrc.json');
+                this.template('_test.eslintrc.json', 'test/.eslintrc.json');
                 break;
         }
 

--- a/app/templates/_.eslintrc.json
+++ b/app/templates/_.eslintrc.json
@@ -1,8 +1,8 @@
 {
     <% if(language === 'babel' || language === 'babel-node4') { %>
     "parser": "babel-eslint",
+    <% } %>
     "env": {
         "es6": true
     }
-    <% } %>
 }

--- a/app/templates/_test.eslintrc.json
+++ b/app/templates/_test.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "parserOptions": {
+        "sourceType": "module"
+    }
+}


### PR DESCRIPTION
We live in the future now so now we go ahead and allow ES6 in JS projects. Also add a config to the test directory so it doesn't complain about es6 module import/export in ava tests.

Fixes #31 