### PR TITLE
Add test to npmignore if !checkInCompiled

### DIFF
--- a/app/templates/_.gitignore
+++ b/app/templates/_.gitignore
@@ -1,4 +1,6 @@
 node_modules/
-<% if(compiled && !checkinCompiled) { %>lib/<% } %>
+<%_ if(compiled && !checkinCompiled) { _%>
+lib/
+<%_ } _%>
 
 *.log

--- a/app/templates/_.npmignore
+++ b/app/templates/_.npmignore
@@ -1,4 +1,7 @@
 node_modules/
-<% if(compiled && !publishSource) { %>src/<% } %>
+<%_ if(compiled && !publishSource) { _%>
+src/
+test/
+<%_ } _%>
 
 *.log


### PR DESCRIPTION
Doesn't make sense to include tests in npm package if you don't include the source. Also fixes the extra whitespace you get in vanilla JS generated projects.
