### PR TITLE
Remove onchange from plain JS projects

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -200,9 +200,12 @@ var NodeModuleGenerator = yeoman.Base.extend({
             pkg[depObjName] = newDepsObj;
         }
 
-        var devDeps = ['ava', 'onchange'];
+        var devDeps = ['ava'];
         var deps = [];
 
+        if (this.compiled) {
+            devDeps.push('onchange');
+        }
         switch(this.language) {
             case 'coffee': devDeps.push('coffee-script', 'coffeelint'); break;
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -31,8 +31,11 @@
 
         "pretest": "npm run lint",
         "test": "ava",
+<% if(compiled) { %>
         "watch": "onchange src/ -- npm run build && echo Done",
         "dev": "npm run watch",
+<% } %>
+
         "prepublish": "npm run test<% if(compiled) { %> && npm run build<% } %>"
     }
 }

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -50,7 +50,9 @@ test.serial('creates expected files for Coffee', async t => {
                 /coffeelint/i.test(pkgJson.scripts.lint) &&
                 /ava/i.test(pkgJson.scripts.test) &&
                 /coffee/i.test(pkgJson.scripts.build) &&
-                /build/i.test(pkgJson.scripts.prepublish)
+                /build/i.test(pkgJson.scripts.prepublish) &&
+                /onchange/i.test(pkgJson.scripts.watch) &&
+                /watch/i.test(pkgJson.scripts.dev)
             ;
         }),
         { tests: verifyTestCount }
@@ -95,7 +97,9 @@ test.serial('creates expected files for Babel', async t => {
                 /eslint/i.test(pkgJson.scripts.lint) &&
                 /ava/i.test(pkgJson.scripts.test) &&
                 /babel/i.test(pkgJson.scripts.build) &&
-                /build/i.test(pkgJson.scripts.prepublish)
+                /build/i.test(pkgJson.scripts.prepublish) &&
+                /onchange/i.test(pkgJson.scripts.watch) &&
+                /watch/i.test(pkgJson.scripts.dev)
             ;
         }),
         { tests: verifyTestCount }
@@ -140,7 +144,9 @@ test.serial('creates expected files for Babel with Node 4 preset', async t => {
                 /eslint/i.test(pkgJson.scripts.lint) &&
                 /ava/i.test(pkgJson.scripts.test) &&
                 /babel/i.test(pkgJson.scripts.build) &&
-                /build/i.test(pkgJson.scripts.prepublish)
+                /build/i.test(pkgJson.scripts.prepublish) &&
+                /onchange/i.test(pkgJson.scripts.watch) &&
+                /watch/i.test(pkgJson.scripts.dev)
             ;
         }),
         { tests: verifyTestCount }
@@ -177,8 +183,10 @@ test.serial('creates expected files for vanilla Javascript', async t => {
             return allExist(expected) && noneExist(['src']) &&
                 /eslint/i.test(pkgJson.scripts.lint) &&
                 /ava/i.test(pkgJson.scripts.test) &&
+                !/build/i.test(pkgJson.scripts.prepublish) &&
                 pkgJson.scripts.build == null &&
-                !/build/i.test(pkgJson.scripts.prepublish)
+                pkgJson.scripts.watch == null &&
+                pkgJson.scripts.dev == null
             ;
         }),
         { tests: verifyTestCount }


### PR DESCRIPTION
The `watch` and `dev` scripts don't work and aren't needed for plain JS projects. This removes them.